### PR TITLE
add generateSignedUserTransactionHex in untils.tx  

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@starcoin/starcoin",
-  "version": "0.1.7",
+  "version": "0.2.0",
   "description": "starcoin js sdk",
   "author": "lerencao",
   "license": "Apache-2.0",

--- a/src/encoding/index.spec.ts
+++ b/src/encoding/index.spec.ts
@@ -1,8 +1,8 @@
 import { addressToSCS, decodeEventKey, decodeTransactionPayload, decodeSignedUserTransaction } from '.';
-import { BcsSerializer, BcsDeserializer } from '../lib/runtime/bcs';
+import { BcsSerializer } from '../lib/runtime/bcs';
 import { toHexString } from '../utils/hex';
 import { JsonrpcProvider } from '../providers/jsonrpc-provider';
-import { encodeScriptFunction, encodeSignedUserTransaction } from "../utils/tx";
+import { encodeScriptFunction, generateSignedUserTransactionHex } from "../utils/tx";
 
 test("encoding address", () => {
   expect(addressToSCS("0x1").value.length).toBe(16);
@@ -78,17 +78,11 @@ test("encoding SignedUserTransaction hex", async () => {
   // expired after 12 hours since Unix Epoch
   const expirationTimestampSecs = nowSeconds + 43200
 
-  const signedUserTransaction = await encodeSignedUserTransaction(senderPrivateKeyHex, senderAddressHex, receiverAddressHex, amount, maxGasAmount, senderSequenceNumber, expirationTimestampSecs, chainId);
-
-  const hex = (function () {
-    const se = new BcsSerializer();
-    signedUserTransaction.serialize(se);
-    return toHexString(se.getBytes());
-  })();
-
+  const hex = await generateSignedUserTransactionHex(senderPrivateKeyHex, senderAddressHex, receiverAddressHex, amount, maxGasAmount, senderSequenceNumber, expirationTimestampSecs, chainId);
   console.log(hex)
+
   const signedUserTransactionDecoded = decodeSignedUserTransaction(hex);
-  // console.log(signedUserTransactionDecoded)
+
   expect(signedUserTransactionDecoded.raw_txn.sender).toBe(senderAddressHex);
 });
 

--- a/src/providers/base-provider.ts
+++ b/src/providers/base-provider.ts
@@ -748,7 +748,7 @@ export abstract class BaseProvider extends Provider {
     if (
       (transactionInfo ? transactionInfo.confirmations : 0) >= confirmations
     ) {
-      return transactionInfo;
+      return Promise.resolve(transactionInfo);
     }
 
     // Poll until the receipt is good...
@@ -1225,10 +1225,9 @@ export abstract class BaseProvider extends Provider {
         }
 
         const transactionInfo = this.formatter.transactionInfo(result);
-
         if (transactionInfo.block_number === null) {
           transactionInfo.confirmations = 0;
-        } else if (transactionInfo.confirmations === null) {
+        } else if (!transactionInfo.confirmations) {
           const blockNumber = await this._getInternalBlockNumber(
             100 + 2 * this.pollingInterval
           );
@@ -1238,9 +1237,9 @@ export abstract class BaseProvider extends Provider {
           if (confirmations <= 0) {
             confirmations = 1;
           }
+
           transactionInfo.confirmations = confirmations;
         }
-
         return transactionInfo;
       },
       { oncePoll: this }

--- a/src/providers/base-provider.ts
+++ b/src/providers/base-provider.ts
@@ -947,16 +947,12 @@ export abstract class BaseProvider extends Provider {
   ): Promise<TransactionResponse> {
     await this.getNetwork();
     const hexTx = await signedTransaction;
-    console.log('basic-provider: sendTransaction')
-    console.log({ hexTx })
     const tx = this.formatter.userTransactionData(hexTx);
-    console.log('tx', tx)
-    console.log('_wrapTransaction', this._wrapTransaction(tx))
     try {
       // FIXME: check rpc call
-      // await this.perform(RPC_ACTION.sendTransaction, {
-      //   signedTransaction: hexTx
-      // });
+      await this.perform(RPC_ACTION.sendTransaction, {
+        signedTransaction: hexTx
+      });
       return this._wrapTransaction(tx);
     } catch (error) {
       (<any>error).transaction = tx;

--- a/src/providers/base-provider.ts
+++ b/src/providers/base-provider.ts
@@ -193,6 +193,7 @@ function base58Encode(data: Uint8Array): string {
 
 export const RPC_ACTION = {
   getChainInfo: 'getChainInfo',
+  getNodeInfo: 'getNodeInfo',
   sendTransaction: 'sendTransaction',
   getBlock: 'getBlock',
   getTransactionByHash: 'getTransactionByHash',
@@ -879,7 +880,7 @@ export abstract class BaseProvider extends Provider {
     if (value) {
       // @ts-ignore
       return Object.entries(value.resources)
-        .reduce((o, [k, v])=>({...o, [k]: this.formatter.moveStruct(v as AnnotatedMoveStruct)}), {});
+        .reduce((o, [k, v]) => ({ ...o, [k]: this.formatter.moveStruct(v as AnnotatedMoveStruct) }), {});
     }
   }
 
@@ -946,12 +947,16 @@ export abstract class BaseProvider extends Provider {
   ): Promise<TransactionResponse> {
     await this.getNetwork();
     const hexTx = await signedTransaction;
+    console.log('basic-provider: sendTransaction')
+    console.log({ hexTx })
     const tx = this.formatter.userTransactionData(hexTx);
+    console.log('tx', tx)
+    console.log('_wrapTransaction', this._wrapTransaction(tx))
     try {
       // FIXME: check rpc call
-      await this.perform(RPC_ACTION.sendTransaction, {
-        signedTransaction: hexTx
-      });
+      // await this.perform(RPC_ACTION.sendTransaction, {
+      //   signedTransaction: hexTx
+      // });
       return this._wrapTransaction(tx);
     } catch (error) {
       (<any>error).transaction = tx;

--- a/src/providers/jsonrpc-provider.spec.ts
+++ b/src/providers/jsonrpc-provider.spec.ts
@@ -1,8 +1,5 @@
 import { JsonrpcProvider } from '.';
-
-const log = (data: any): void => {
-  console.log(JSON.stringify(data, undefined, 2))
-}
+import { generateSignedUserTransactionHex } from '../utils/tx';
 
 describe('jsonrpc-provider', () => {
   // let provider = new JsonrpcProvider("http://39.102.41.156:9850", undefined);
@@ -37,7 +34,7 @@ describe('jsonrpc-provider', () => {
     const events = await provider.getTransactionEvents({
       event_keys: []
     });
-    log(events);
+    console.log(JSON.stringify(events, undefined, 2));
   });
 
   test('call contract', async () => {
@@ -46,7 +43,7 @@ describe('jsonrpc-provider', () => {
       type_args: ['0x1::STC::STC'],
       args: ['0x1'],
     });
-    log(values);
+    console.log(JSON.stringify(values, undefined, 2));
   });
 
   test('get code', async () => {
@@ -69,9 +66,10 @@ describe('jsonrpc-provider', () => {
     let balances = await provider.getBalances("0x1");
   });
 
-  test('txn sign and submit', async () => {
+  test('txn sign using sender password and submit', async () => {
     const signer = await provider.getSigner();
-    await signer.unlock("");
+    const password = ""; // put password into the quotes
+    await signer.unlock(password);
     const txnRequest = {
       script: {
         code: '0x1::TransferScripts::peer_to_peer',
@@ -93,14 +91,46 @@ describe('jsonrpc-provider', () => {
     } else {
       expect(balance).toBe(100000);
     }
-
   }, 10000);
 
-  test('SignedUserTransaction', async () => {
-    const senderAddress = '0x49624992dd72da077ee19d0be210406a'
-    const receiverAddress = '0x621500bf2b4aad17a690cb24f9a225c6'
-    const signer = provider.getSigner(senderAddress);
-    const balanceBefore = await provider.getBalance(receiverAddress);
-    log({ balanceBefore })
+  test('txn sign using sender privateKey and submit', async () => {
+    // privateKey is generated in starcoin console using command:
+    // starcoin% account export <ADDRESS> -p <PASSWORD>
+    const senderPrivateKeyHex = '0x83c7829c68e1ad81ced10f69d11ea741f7f18c7a5f059215e8a965362a5ae25e'
+
+    const senderAddressHex = '0x49624992dd72da077ee19d0be210406a'
+
+    const senderSequenceNumber = await provider.getSequenceNumber(senderAddressHex)
+
+    const receiverAddressHex = '0x621500bf2b4aad17a690cb24f9a225c6'
+
+    const amount = 1000000000
+
+    // TODO: generate maxGasAmount from contract.dry_run -> gas_used
+    const maxGasAmount = 124191
+
+    // because the time system in dev network is relatively static, 
+    // we should use nodeInfo.now_secondsinstead of using new Date().getTime()
+    const nowSeconds = await provider.getNowSeconds()
+    // expired after 12 hours since Unix Epoch
+    const expirationTimestampSecs = nowSeconds + 43200
+
+    const signedUserTransactionHex = await generateSignedUserTransactionHex(senderPrivateKeyHex, senderAddressHex, receiverAddressHex, amount, maxGasAmount, senderSequenceNumber, expirationTimestampSecs, chainId);
+
+    console.log({ signedUserTransactionHex })
+
+    const balanceBefore = await provider.getBalance(receiverAddressHex);
+    const txn = await provider.sendTransaction(signedUserTransactionHex);
+    const txnInfo = await txn.wait(1);
+    const balance = await provider.getBalance(receiverAddressHex);
+    if (balanceBefore !== undefined) {
+      // @ts-ignore
+      const diff = balance - balanceBefore;
+      expect(diff).toBe(amount);
+    } else {
+      expect(balance).toBe(amount);
+    }
   }, 10000);
+
 });
+

--- a/src/providers/websocket-provider.spec.ts
+++ b/src/providers/websocket-provider.spec.ts
@@ -30,7 +30,7 @@ describe('websocket-provider', () => {
   });
 
   test('call contract', async () => {
-    const values = await provider.call( {
+    const values = await provider.call({
       function_id: '0x1::Account::balance',
       type_args: ['0x1::STC::STC'],
       args: ['0x1'],
@@ -49,9 +49,10 @@ describe('websocket-provider', () => {
   });
 
 
-  test('txn sign and submit', async () => {
+  test('txn sign using sender password and submit', async () => {
     const signer = await provider.getSigner();
-    await signer.unlock("");
+    const password = ""; // put password into the quotes
+    await signer.unlock(password);
     const txnRequest = {
       script: {
         code: '0x1::TransferScripts::peer_to_peer',


### PR DESCRIPTION
test_dapp can use this function to sign a transaction using privateKey and submit.
no need to use account password and call account.unlock | account.sign_txn_request

related pr in test_dapp:
https://github.com/starcoinorg/test-dapp/pull/1