### PR TITLE
add utils.tx.encodeStructTypeTags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file, as of versi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2021-06-27
+- add utils.tx.encodeStructTypeTags
+
+## [1.2.1] - 2021-06-14
+- fix: hexStripZeros will delete the first 0 if address is start with 0x0, use addHexPrefix indeed
+
+## [1.2.0] - 2021-06-12
+- payload of generateRawUserTransaction should be caculated from outside and be passed in 
+- add test case for 0x1::DaoVoteScripts::cast_vote
+
 ## [1.1.0] - 2021-06-11
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@starcoin/starcoin",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "starcoin js sdk",
   "author": "lerencao, wk3368, tarvos21",
   "license": "Apache-2.0",

--- a/src/encoding/index.ts
+++ b/src/encoding/index.ts
@@ -47,8 +47,8 @@ export function decodeSignedUserTransaction(
 ): SignedUserTransactionView {
   const bytes = arrayify(data);
   const scsData = (function () {
-    const se = new BcsDeserializer(bytes);
-    return starcoin_types.SignedUserTransaction.deserialize(se);
+    const de = new BcsDeserializer(bytes);
+    return starcoin_types.SignedUserTransaction.deserialize(de);
   })();
 
   let authenticator;


### PR DESCRIPTION
1. add utils.tx.encodeStructTypeTags: while generating ScriptFunction, we need to encode a string array into a TypeTag array
2. add 2 test cases
3. update the existing associated codes
4. modify CHANGELOG
5. bump version to 1.3.0
   
demo 1:

```
 [ '0x1::STC::STC' ]

  [
    {
      "Struct": {
        "address": "0x1",
        "module": "STC",
        "name": "STC",
        "type_params": []
      }
    }
  ]

```

demo2:
```
  [
    '0x1::STC::STC',
    '0x1::OnChainConfigDao::OnChainConfigUpdate<0x1::TransactionPublishOption::TransactionPublishOption>'
  ]


  [
    {
      "Struct": {
        "address": "0x1",
        "module": "STC",

        "name": "STC",
        "type_params": []
      }
    },
    {
      "Struct": {
        "address": "0x1",
        "module": "OnChainConfigDao",
        "name": "OnChainConfigUpdate",
        "type_params": [
          {
            "Struct": {
              "address": "0x1",
              "module": "TransactionPublishOption",
              "name": "TransactionPublishOption",
              "type_params": []
            }
          }
        ]
      }
    }
  ]
```