### PR TITLE
support personal sign 

### DIFF
--- a/src/utils/sign.spec.ts
+++ b/src/utils/sign.spec.ts
@@ -1,0 +1,46 @@
+import * as ed from '@starcoin/stc-ed25519';
+import { arrayify, hexlify } from '@ethersproject/bytes';
+import { encodeTransactionAuthenticator, decodeTransactionAuthenticator } from "./sign";
+import { publicKeyToAddress } from "../encoding";
+
+// const exampleMessage = 'helloworld'
+const exampleMessage = 'Example `personal_sign` message 中文 1'
+const msgBytes = new Uint8Array(Buffer.from(exampleMessage, 'utf8'))
+// const msgHex = Buffer.from(exampleMessage, 'utf8').toString('hex')
+const publicKey = '0x32ed52d319694aebc5b52e00836e2f7c7d2c7c7791270ede450d21dbc90cbfa1'
+const privateKey = '0x587737ebefb4961d377a3ab2f9ceb37b1fa96eb862dfaf954a4a1a99535dfec0'
+const address = '0xd7f20befd34b9f1ab8aeae98b82a5a51'
+const publicKeyBytes = arrayify(publicKey)
+const privateKeyBytes = arrayify(privateKey)
+
+test('encode and decode transactionAuthenticator', async () => {
+  const transactionAuthenticatorHex = encodeTransactionAuthenticator(publicKeyBytes, msgBytes)
+  // console.log({ transactionAuthenticatorHex })
+
+  const transactionAuthenticator = decodeTransactionAuthenticator(transactionAuthenticatorHex)
+  // console.log(transactionAuthenticator.publicKey, transactionAuthenticator.signature)
+  // console.log('decoded publicKey:', hexlify(transactionAuthenticator.publicKey))
+  const arraybuffer = transactionAuthenticator.signature.buffer
+  const buffer = Buffer.from(arraybuffer);
+  // console.log('decoded Message:', buffer.toString('utf-8'))
+
+  (async () => {
+    const addressSigned = publicKeyToAddress(hexlify(transactionAuthenticator.publicKey))
+    // console.log({ addressSigned })
+    expect(addressSigned).toBe(address);
+  })();
+
+  expect(hexlify(transactionAuthenticator.publicKey)).toBe(publicKey)
+  expect(buffer.toString('utf-8')).toBe(exampleMessage)
+})
+
+test('sign and verify', () => {
+  (async () => {
+    const transactionAuthenticatorHex = encodeTransactionAuthenticator(publicKeyBytes, msgBytes)
+    // console.log({ transactionAuthenticatorHex })
+    const signature = await ed.sign(transactionAuthenticatorHex, privateKeyBytes);
+    const isSigned = await ed.verify(signature, transactionAuthenticatorHex, publicKeyBytes);
+    // console.log({ signature })
+    expect(isSigned).toBe(true);
+  })();
+})

--- a/src/utils/sign.ts
+++ b/src/utils/sign.ts
@@ -1,0 +1,26 @@
+import { arrayify, hexlify } from '@ethersproject/bytes';
+import { BcsSerializer, BcsDeserializer } from '../lib/runtime/bcs';
+import { Ed25519PublicKey, Ed25519Signature, TransactionAuthenticator, TransactionAuthenticatorVariantEd25519 } from '../lib/runtime/starcoin_types';
+import { bytes } from '../lib/runtime/serde/types';
+
+export function encodeTransactionAuthenticator(publicKey: bytes, msgBytes: bytes): string {
+  const ed25519PublicKey = new Ed25519PublicKey(publicKey)
+  const ed25519Signature = new Ed25519Signature(msgBytes)
+  const authenticatorEd25519 = new TransactionAuthenticatorVariantEd25519(ed25519PublicKey, ed25519Signature)
+  // console.log(authenticatorEd25519)
+  const se = new BcsSerializer();
+  authenticatorEd25519.serialize(se);
+  // console.log('se.getBytes():', se.getBytes())
+  const hex = hexlify(se.getBytes());
+  return hex;
+}
+
+export function decodeTransactionAuthenticator(signatureHex: string): { publicKey: bytes, signature: bytes } {
+  const signatureBytes = arrayify(signatureHex)
+  const de = new BcsDeserializer(signatureBytes);
+  const authenticatorEd25519 = <TransactionAuthenticatorVariantEd25519>TransactionAuthenticator.deserialize(de);
+  const publicKey = authenticatorEd25519.public_key.value
+  const signature = authenticatorEd25519.signature.value
+  return { publicKey, signature }
+}
+


### PR DESCRIPTION
we need to integrate publicKey with message into TransactionAuthenticator for sign.
the benifit is that we can later decode and get the signed address from the publicKey.

1. add 2 functions in utils/sign: encodeTransactionAuthenticator / decodeTransactionAuthenticator
2. add 2 test cases: 
yarn test:unit src/utils/sign.spec.ts --testNamePattern="encode"
yarn test:unit src/utils/sign.spec.ts --testNamePattern="sign"
