### PR TITLE
feat: change halley chainId to 253

### DIFF
--- a/src/networks/index.ts
+++ b/src/networks/index.ts
@@ -46,7 +46,7 @@ const STANDARD_NETWORKS: { [name: string]: Network } = {
     name: 'barnard',
   },
   halley: {
-    chainId: 3,
+    chainId: 253,
     name: 'halley',
   },
   proxima: {


### PR DESCRIPTION
Now the chainID of the halley network is 253, and the current project configuration is 3. Through provider.callV2, it will prompt that the network is incorrect:

Error: underlying network changed (event="changed", network={"name":"halley","chainId":3,"_defaultProvider":null}, detectedNetwork={"chainId":253,"name":" unknown"}, code=NETWORK_ERROR, version=2.1.6)